### PR TITLE
Scraper 로직 구현

### DIFF
--- a/youboard_server/channel_scraper.py
+++ b/youboard_server/channel_scraper.py
@@ -1,0 +1,63 @@
+# wizdeo에서 유투브 채널 순위 top 100을 scrap.
+import requests
+import pathlib
+import time
+from selenium import webdriver
+from datetime import datetime
+
+
+def get_login_info():
+    with open("wiz.txt", "r") as f:
+        user_email = f.readline().strip('\n')
+        user_pw = f.readline().strip('\n')
+        return user_email, user_pw
+
+def initialize_scraper(driver, url):
+    driver.get(url)
+
+def login(driver, user_email, user_pw):
+    driver.find_element_by_xpath('/html/body/div[1]/div/div[2]/div[2]/ul/li[2]/a').click()
+    email = driver.find_element_by_id('UserEmail')
+    email.send_keys(user_email)
+    pw = driver.find_element_by_id('UserPassword')
+    pw.send_keys(user_pw)
+    driver.find_element_by_xpath('//*[@id="UserLoginForm"]/div[4]/button').click()
+
+def html_to_object(driver, n):
+    common_xpath = '//*[@id="content-main"]/div[1]/div[2]/div[3]/div[4]/div/table/tbody/tr[' + str(n) + ']'
+    rank = driver.find_element_by_xpath(common_xpath + '/td[2]').text[:-2]
+    name = driver.find_element_by_xpath(common_xpath + '/td[3]').text
+    category = driver.find_element_by_xpath(common_xpath + '/td[4]').text
+    country = driver.find_element_by_xpath(common_xpath + '/td[8]').text
+    subscribers = driver.find_element_by_xpath(common_xpath + '/td[12]').text.split('+')[0]
+    url = driver.find_element_by_xpath(common_xpath + '/td[3]/div/div[3]/a').get_attribute("href")
+    channel = {
+        'rank': rank,
+        'name': name,
+        'category':category,
+        'country':country,
+        'subscribers':subscribers,
+        'url':url
+    }
+    return channel
+
+def channel_scrap():
+    driver = webdriver.Chrome('.\\chromedriver.exe')
+    user_email, user_pw = get_login_info()
+    url_base = 'https://analytics.wizdeo.com/en/channels/search?country[in][0]=kr&search=&sort=score'
+    url_args = '&direction=desc&colgroups=classification,statistics,score&limit=50&evolution=_1w'
+    url = url_base + url_args
+    initialize_scraper(driver, url)
+    login(driver, user_email, user_pw)
+    next_path = '//*[@id="content-main"]/div[1]/div[2]/div[3]/div[6]/ul/li[3]/a'
+    channels = []
+    # 페이지당 50개 x 2페이지
+    for page in range(2):
+        for n in range(1, 51):
+            channels.append(html_to_object(driver, n))
+        #페이지 넘김
+        element = driver.find_element_by_xpath(next_path)
+        element.location_once_scrolled_into_view
+        driver.execute_script("arguments[0].scrollIntoView();", element)
+        element.click()
+    return channels

--- a/youboard_server/mongo_connect.py
+++ b/youboard_server/mongo_connect.py
@@ -11,11 +11,12 @@ mongo = PyMongo(app)
 
 @app.route('/channel-scraper')
 def scrap_channel():
-    channelCollection = mongo.db.channel
+    channel_collection = mongo.db.channel
+    channel_collection.remove({ })
     channels = channel_scraper.channel_scrap()
     for channel in channels:
-        channelCollection.insert(channel)
-    return 'Completed to scrap 100 channels!'
+        channel_collection.insert(channel)
+    return 'Completed to scrap channels!'
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/youboard_server/mongo_connect.py
+++ b/youboard_server/mongo_connect.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_pymongo import PyMongo
 import channel_scraper
+import video_scraper
 
 app = Flask(__name__)
 
@@ -16,7 +17,22 @@ def scrap_channel():
     channels = channel_scraper.channel_scrap()
     for channel in channels:
         channel_collection.insert(channel)
-    return 'Completed to scrap channels!'
+    result = []
+    for channel in channel_collection.find():
+        result.append(channel)
+    return " ".join(str(x) for x in result)
+
+@app.route('/video-scraper')
+def scrap_video():
+    video_collection = mongo.db.video
+    video_collection.remove({ })
+    videos = video_scraper.video_scrap()
+    for video in videos:
+        video_collection.insert(video)
+    result = []
+    for video in video_collection.find():
+        result.append(video)
+    return " ".join(str(x) for x in result)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/youboard_server/mongo_connect.py
+++ b/youboard_server/mongo_connect.py
@@ -1,0 +1,21 @@
+from flask import Flask
+from flask_pymongo import PyMongo
+import channel_scraper
+
+app = Flask(__name__)
+
+app.config['MONGO_DBNAME'] = 'youboard'
+app.config['MONGO_URI'] = 'mongodb://youboard:youboard2019@ds155614.mlab.com:55614/youboard'
+
+mongo = PyMongo(app)
+
+@app.route('/channel-scraper')
+def scrap_channel():
+    channelCollection = mongo.db.channel
+    channels = channel_scraper.channel_scrap()
+    for channel in channels:
+        channelCollection.insert(channel)
+    return 'Completed to scrap 100 channels!'
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/youboard_server/video_scraper.py
+++ b/youboard_server/video_scraper.py
@@ -1,0 +1,74 @@
+# wizdeo에서 유투브 인기영상 top 100을 스크래이핑.
+import pathlib
+import time
+from selenium import webdriver
+from datetime import datetime
+
+
+URL_BASE = 'https://analytics.wizdeo.com/en/videos/search?country%5Bin%5D%5B0%5D=kr'
+URL_ARGS = '&limit=50&evolution=_1w&sort=NOVideo.views_1w&direction=desc'
+
+NEXT_PATH = '//*[@id="content-main"]/div[1]/div[2]/div[5]/div[6]/ul/li[3]/a'
+
+def get_login_info():
+    with open("wiz.txt", "r") as f:
+        user_email = f.readline().strip('\n')
+        user_pw = f.readline().strip('\n')
+        return user_email, user_pw
+
+def initialize_scraper(driver, url):
+    driver.get(url)
+
+def login(driver, user_email, user_pw):
+    driver.find_element_by_xpath('/html/body/div[1]/div/div[2]/div[2]/ul/li[2]/a').click()
+    email = driver.find_element_by_id('UserEmail')
+    email.send_keys(user_email)
+    pw = driver.find_element_by_id('UserPassword')
+    pw.send_keys(user_pw)
+    driver.find_element_by_xpath('//*[@id="UserLoginForm"]/div[4]/button').click()
+
+def html_to_object(driver, n):
+    common_xpath = '//*[@id="content-main"]/div[1]/div[2]/div[5]/div[4]/div/table/tbody/tr[' + str(n) + ']'
+    rank = driver.find_element_by_xpath(common_xpath + '/td[2]').text[:-2]
+    name = driver.find_element_by_xpath(common_xpath + '/td[3]').text
+    channel = driver.find_element_by_xpath(common_xpath + '/td[4]').text
+    category = driver.find_element_by_xpath(common_xpath + '/td[5]').text
+    views = driver.find_element_by_xpath(common_xpath + '/td[8]/div/span').text
+    lastWeekViews = driver.find_element_by_xpath(common_xpath + '/td[8]/div/div').text.split('+')[1]
+    url = driver.find_element_by_xpath(common_xpath + '/td[3]/div/div[2]/div/a').get_attribute("href")
+    video = {
+        'rank': rank,
+        'name': name,
+        'channel': channel,
+        'category': category,
+        'views': views,
+        'lastWeekViews': lastWeekViews,
+        'url': url
+    }
+    print(video)
+    return video
+
+def turn_page(driver):
+    element = driver.find_element_by_xpath(NEXT_PATH)
+    element.location_once_scrolled_into_view
+    driver.execute_script("arguments[0].scrollIntoView();", element)
+    element.click()
+
+def video_scrap():
+    driver = webdriver.Chrome('.\\chromedriver.exe')
+    user_email, user_pw = get_login_info()
+    url = URL_BASE + URL_ARGS
+    initialize_scraper(driver, url)
+    login(driver, user_email, user_pw)
+    videos = []
+    # 페이지당 50개 x 2페이지
+    for page in range(2):
+        for n in range(1, 51):
+            videos.append(html_to_object(driver, n))
+        if page == 1:
+            break
+        turn_page(driver)
+    return videos
+
+if __name__ == "__main__":
+    video_scrap()


### PR DESCRIPTION
## video, channel scraper

- 아이디/비밀번호가 담긴 wiz.txt는 git에 올리지 않았습니다

- channel scraper는 300개를 scraping합니다. 이 중에서 100개를 select해서 channel탭에서 쓰고, 나머지는 유투버를 추려내서 유투버 탭에 쓰려고 합니다.

- 플라스크 서버에서 해당 url을 치면 스크래핑이 시작되고, 결과를 우선 string으로 리턴하도록 짰습니다. (추후 template이나 연결되는 로직으로 변경)